### PR TITLE
Remove single reaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The default variables for being able to run locally have been added to `./script
 
 ```sh
 mkdir ./local
-echo `#!/bin/bash\n\nDISCORD_BOT={your token goes here}\n` > ./local/variables
+echo $'#!/bin/bash\n\nDISCORD_TOKEN={your token goes here}\n' > ./local/variables
 chmod +x ./local/variables
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -189,6 +189,15 @@
       "integrity": "sha512-dIOxFfI0C+jz89g6lQ+TqhGgPQ0MxSnh/E4xuC0blhFtyW269+mPG5QeLgbdwst/LvdP8o1y0o/Gz5EHXLec/g==",
       "dev": true
     },
+    "@types/bluebird-retry": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/@types/bluebird-retry/-/bluebird-retry-0.11.4.tgz",
+      "integrity": "sha512-A7ZCQmNlwXLhDhsoLapARTWKFdP+xmRAhONVMiVk3SNcT9l54f20R5ogRJ75A6oDN/EgoBRx2W45oeN2DppARQ==",
+      "dev": true,
+      "requires": {
+        "@types/bluebird": "*"
+      }
+    },
     "@types/chai": {
       "version": "4.2.12",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
@@ -326,6 +335,11 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "bluebird-retry": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird-retry/-/bluebird-retry-0.11.0.tgz",
+      "integrity": "sha1-EomrIsu8OgJYe6rTVZU1HdDBwEc="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     "dependencies": {
         "axios": "^0.20.0",
         "bluebird": "^3.7.2",
+        "bluebird-retry": "^0.11.0",
         "discord.js": "^12.4.0",
         "minimist": "^1.2.5",
         "moment": "^2.27.0"
     },
     "devDependencies": {
         "@types/bluebird": "^3.5.32",
+        "@types/bluebird-retry": "^0.11.4",
         "@types/chai": "^4.2.4",
         "@types/chai-as-promised": "^7.1.2",
         "@types/mocha": "^5.2.7",

--- a/src/events/event-manager.ts
+++ b/src/events/event-manager.ts
@@ -11,7 +11,7 @@ export class EventManager {
     getHooks(): Hook[] {
         return [{
             name: this.hookName,
-            listener: async(...args: any[]) => {
+            listener: async (...args: any[]) => {
                 const handlers = this.handlers.filter(handler => handler.supported.call(handler, ...args));
 
                 if (!handlers.length) {

--- a/src/events/message-reaction-remove/handlers/cancel-training-request.ts
+++ b/src/events/message-reaction-remove/handlers/cancel-training-request.ts
@@ -1,0 +1,21 @@
+import { User, MessageReaction, PartialUser } from 'discord.js';
+
+import { EventHandler } from '../types';
+
+export class CancelTrainingRequestHandler implements EventHandler {
+    constructor(
+        private readonly messageId: string,
+        private readonly emojiName: string
+    ) { }
+
+    supported(messageReaction: MessageReaction, user: User | PartialUser): boolean {
+        return messageReaction.emoji.name === this.emojiName && messageReaction.message.id === this.messageId;
+    }
+
+    async handle(messageReaction: MessageReaction, user: User): Promise<void> {
+        // When a user requests training using the reaction of an emoji on the requestTraining message,
+        // the code will automatically remove the reaction, and this function will be invoked..
+        // Theres nothing for us to do, this just helps prevent the logger from warning us that we have no
+        // handler to handle this event
+    }
+}

--- a/src/events/message-reaction-remove/handlers/index.ts
+++ b/src/events/message-reaction-remove/handlers/index.ts
@@ -1,1 +1,2 @@
+export * from './cancel-training-request';
 export * from './revoke-role';

--- a/src/events/message/event-manager.ts
+++ b/src/events/message/event-manager.ts
@@ -16,7 +16,7 @@ export class EventManager {
     getHooks(): Hook[] {
         return [{
             name: 'message',
-            listener: async(message: Message) => {
+            listener: async (message: Message) => {
                 const messagePrefixMatched = this.messagePrefixRegex.test(message.content);
                 if (!messagePrefixMatched) {
                     return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,9 +54,10 @@ const messageReactionAddEventManager = new GenericEventManager('messageReactionA
 
 // -----------------------------------------------------
 // Message Reaction Remove
+const cancelTrainingRequestHandler = new MessageReactionRemove.CancelTrainingRequestHandler(config.requestTrainingMessageId, '🗒️');
 const revokeNotificationsRoleHandler = new MessageReactionRemove.RevokeRoleHandler(config.notificationRoleName, config.notificationRoleMessageId, '✅', discordClient.extractMessageProps.bind(discordClient), logger);
 
-const messageReactionRemoveEventHandlers = [revokeNotificationsRoleHandler];
+const messageReactionRemoveEventHandlers = [cancelTrainingRequestHandler, revokeNotificationsRoleHandler];
 const messageReactionRemoveEventManager = new GenericEventManager('messageReactionRemove', messageReactionRemoveEventHandlers, logger);
 
 // -----------------------------------------------------

--- a/src/lib/discord-helpers.ts
+++ b/src/lib/discord-helpers.ts
@@ -1,51 +1,52 @@
 import { MessageReaction, GuildMember, User, PartialUser, TextChannel, MessageEmbed } from 'discord.js';
-import { Logger } from './logger';
 import { VatsimApi } from './vatsim';
 import { AppError } from './errors';
+import { factory } from './helpers';
 
-export const resetMessageReaction = async function(messageReaction: MessageReaction, logger: Logger): Promise<void> {
-    await messageReaction.message.reactions.removeAll()
-        .catch(error => {
-            logger.error(`Error removing reactions to message ${messageReaction.message.id}: ${error}`);
-        });
+export const resetMessageReaction = async (messageReaction: MessageReaction): Promise<void> => {
+    await messageReaction.message.reactions.removeAll();
 };
 
-export const applyReactionToMessage = async function(messageReaction: MessageReaction, emojiName: string): Promise <void> {
+export const applyReactionToMessage = async (messageReaction: MessageReaction, emojiName: string): Promise<void> => {
     await messageReaction.message.react(emojiName);
 };
 
-export const extractUserCidFromGuildMember = function(member: GuildMember): string {
+export const extractUserCidFromGuildMember = (member: GuildMember): string => {
     const nickname = member && (member.nickname || member.user?.username);
-        if (!nickname) {
-            throw new AppError(`User's VATSIM CID could not be determined.`);
-        }
-        
-        let vatsimCid = nickname.substring(nickname.length - 7);
-        if (vatsimCid.length !== 7 || !+vatsimCid) {
-            throw new AppError(`User's VATSIM CID could not be determined.`);
-        }
+    if (!nickname) {
+        throw new AppError(`User's VATSIM CID could not be determined.`);
+    }
 
-        return vatsimCid;
+    let vatsimCid = nickname.substring(nickname.length - 7);
+    if (vatsimCid.length !== 7 || !+vatsimCid) {
+        throw new AppError(`User's VATSIM CID could not be determined.`);
+    }
+
+    return vatsimCid;
 };
 
-export const getVatsimUser = async function(vatsimApi: VatsimApi, cid: string): Promise<any> {
+export const getVatsimUser = async (vatsimApi: VatsimApi, cid: string): Promise<any> => {
     const apiInstance = await vatsimApi.getApiInstance();
     return vatsimApi.getVatsimUser(apiInstance, cid);
 };
 
-export const constructEmbeddedMessage = function(header: string, message: string, avatarUrl: string): MessageEmbed {
+export const constructEmbeddedMessage = (header: string, message: string, avatarUrl: string): MessageEmbed => {
     return new MessageEmbed()
         .setAuthor(header, avatarUrl)
         .setDescription(message);
 };
 
-export const sendMessageToUser = async function(header: string, message: string, user: User | PartialUser): Promise<void> {
+export const sendMessageToUser = async (header: string, message: string, user: User | PartialUser): Promise<void> => {
     // Should we be sending the bot's avatar instead?
     const embeddedMessage = constructEmbeddedMessage(header, message, user.avatarURL());
     await user.send(embeddedMessage);
 };
 
-export const sendMessageToChannel = async function(header: string, message: string, channel: TextChannel, avatarUrl: string): Promise<void> {
+export const sendMessageToChannel = async (header: string, message: string, channel: TextChannel, avatarUrl: string): Promise<void> => {
     const embeddedMessage = constructEmbeddedMessage(header, message, avatarUrl);
     await channel.send(embeddedMessage);
+};
+
+export const removeUserFromMessageReaction = async (messageReaction: MessageReaction, user: User): Promise<void> => {
+    await factory.defaultRetry<MessageReaction>(() => messageReaction.users.remove(user));
 };

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,4 +1,6 @@
-export function jsonReviver(key: string , value: any): any {
+import BlueBirdRetry from 'bluebird-retry';
+
+export function jsonReviver(key: string, value: any): any {
     if (typeof value === 'string') {
         if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/.test(value)) {
             return new Date(value);
@@ -15,3 +17,17 @@ export function jsonReviver(key: string , value: any): any {
 export function jsonParser(value: string, reviver?: (key: string, value: any) => any): any {
     return JSON.parse(value, reviver || jsonReviver);
 }
+
+export async function defaultRetry<T = any>(func: () => T | Promise<T>): Promise<T> {
+    return factory.retry<T>(func, { max_tries: 5, interval: 25, backoff: 2 });
+}
+
+export async function retry<T = any>(func: () => T | Promise<T>, options: BlueBirdRetry.Options): Promise<T> {
+    return BlueBirdRetry<T>(func, { throw_original: true, ...options });
+}
+
+// https://stackoverflow.com/questions/39861674/stubbing-method-in-same-file-using-sinon
+export const factory = {
+    defaultRetry,
+    retry
+};

--- a/test/unit/events/message-reaction-add/handlers/request-training.test.ts
+++ b/test/unit/events/message-reaction-add/handlers/request-training.test.ts
@@ -16,7 +16,7 @@ describe('RequestTrainingHandler', () => {
     let getTextChannel: sinon.SinonStub<[string], TextChannel>;
     let vatsimApi: StubbedInstance<VatsimApi>;
     let logger: StubbedInstance<Logger>;
-    
+
     let handler: RequestTrainingHandler;
 
     let sandbox: sinon.SinonSandbox;
@@ -57,7 +57,7 @@ describe('RequestTrainingHandler', () => {
             const calendarUrl = '?test=true&date=';
 
             handler = new RequestTrainingHandler(messageId, emojiName, trainingRequestChannelId, getTextChannel, calendarUrl, vatsimApi, logger);
-            
+
             handler.should.be.deep.equal({
                 messageId,
                 emojiName,
@@ -115,7 +115,7 @@ describe('RequestTrainingHandler', () => {
             should().not.exist(user);
 
             return Promise.resolve()
-            .then(() => handler.supported(messageReaction, user))
+                .then(() => handler.supported(messageReaction, user))
                 .then(() => {
                     throw new Error('Expected an error to be thrown but got success');
                 }, err => {
@@ -129,7 +129,7 @@ describe('RequestTrainingHandler', () => {
             should().not.exist(messageReaction.message);
 
             return Promise.resolve()
-            .then(() => handler.supported(messageReaction, user))
+                .then(() => handler.supported(messageReaction, user))
                 .then(() => {
                     throw new Error('Expected an error to be thrown but got success');
                 }, err => {
@@ -176,8 +176,7 @@ describe('RequestTrainingHandler', () => {
         let user: StubbedInstance<User>;
 
         let giveTrainingStub: sinon.SinonStub<[User | PartialUser, MessageReaction], Promise<void>>;
-        let resetMessageReactionStub: sinon.SinonStub<[MessageReaction, Logger], Promise<void>>;
-        let applyReactionToMessageStub: sinon.SinonStub<[MessageReaction, string], Promise<void>>;
+        let removeUserFromMessageReactionStub: sinon.SinonStub<[MessageReaction, User], Promise<void>>;
 
         beforeEach(() => {
             messageReaction = stubInterface<MessageReaction>();
@@ -187,8 +186,27 @@ describe('RequestTrainingHandler', () => {
             } as User);
 
             giveTrainingStub = sandbox.stub(handler, 'giveTraining').resolves(undefined);
-            resetMessageReactionStub = sandbox.stub(discordHelpers, 'resetMessageReaction').resolves(undefined);
-            applyReactionToMessageStub = sandbox.stub(discordHelpers, 'applyReactionToMessage').resolves(undefined);
+            removeUserFromMessageReactionStub = sandbox.stub(discordHelpers, 'removeUserFromMessageReaction').resolves(undefined);
+        });
+
+        it('should reject with any error thrown by removeUserFromMessageReaction()', () => {
+            const error = new Error('Some fake error');
+            removeUserFromMessageReactionStub.rejects(error);
+
+            return handler.handle(messageReaction, user)
+                .then(result => {
+                    removeUserFromMessageReactionStub.should.have.been.calledOnce;
+                    removeUserFromMessageReactionStub.should.have.been.calledWithExactly(messageReaction, user);
+
+                    giveTrainingStub.should.not.have.been.called;
+
+                    logger.info.should.not.have.been.called;
+
+                    logger.error.should.have.been.calledOnce;
+                    logger.error.should.have.been.calledWithExactly(`Training request unsuccessful for ${username} (${userId})`);
+
+                    should().not.exist(result);
+                });
         });
 
         it('should resolve void after swallowing any error thrown by handler.giveTraining()', () => {
@@ -200,55 +218,8 @@ describe('RequestTrainingHandler', () => {
                     giveTrainingStub.should.have.been.calledOnce;
                     giveTrainingStub.should.have.been.calledWithExactly(user, messageReaction);
 
-                    resetMessageReactionStub.should.not.have.been.called;
-                    applyReactionToMessageStub.should.not.have.been.called;
-
-                    logger.info.should.not.have.been.called;
-
-                    logger.error.should.have.been.calledOnce;
-                    logger.error.should.have.been.calledWithExactly(`Training request unsuccessful for ${username} (${userId})`);
-
-                    should().not.exist(result);
-                });
-        });
-
-        it('should resolve void after swallowing any error thrown by resetMessageReaction()', () => {
-            const error = new Error('Some fake error');
-            resetMessageReactionStub.rejects(error);
-
-            return handler.handle(messageReaction, user)
-                .then(result => {
-                    giveTrainingStub.should.have.been.calledOnce;
-                    giveTrainingStub.should.have.been.calledWithExactly(user, messageReaction);
-
-                    resetMessageReactionStub.should.have.been.calledOnce;
-                    resetMessageReactionStub.should.have.been.calledWithExactly(messageReaction, logger);
-
-                    applyReactionToMessageStub.should.not.have.been.called;
-
-                    logger.info.should.not.have.been.called;
-
-                    logger.error.should.have.been.calledOnce;
-                    logger.error.should.have.been.calledWithExactly(`Training request unsuccessful for ${username} (${userId})`);
-
-                    should().not.exist(result);
-                });
-        });
-
-        it('should resolve void after swallowing any error thrown by applyReactionToMessage()', () => {
-            const error = new Error('Some fake error');
-            applyReactionToMessageStub.rejects(error);
-
-            return handler.handle(messageReaction, user)
-                .then(result => {
-                    giveTrainingStub.should.have.been.calledOnce;
-                    giveTrainingStub.should.have.been.calledWithExactly(user, messageReaction);
-
-                    resetMessageReactionStub.should.have.been.calledOnce;
-                    resetMessageReactionStub.should.have.been.calledWithExactly(messageReaction, logger);
-
-                    applyReactionToMessageStub.should.have.been.calledOnce;
-                    applyReactionToMessageStub.should.have.been.calledWithExactly(messageReaction, emojiName);
+                    removeUserFromMessageReactionStub.should.have.been.calledOnce;
+                    removeUserFromMessageReactionStub.should.have.been.calledWithExactly(messageReaction, user);
 
                     logger.info.should.not.have.been.called;
 
@@ -265,11 +236,8 @@ describe('RequestTrainingHandler', () => {
                     giveTrainingStub.should.have.been.calledOnce;
                     giveTrainingStub.should.have.been.calledWithExactly(user, messageReaction);
 
-                    resetMessageReactionStub.should.have.been.calledOnce;
-                    resetMessageReactionStub.should.have.been.calledWithExactly(messageReaction, logger);
-
-                    applyReactionToMessageStub.should.have.been.calledOnce;
-                    applyReactionToMessageStub.should.have.been.calledWithExactly(messageReaction, emojiName);
+                    removeUserFromMessageReactionStub.should.have.been.calledOnce;
+                    removeUserFromMessageReactionStub.should.have.been.calledWithExactly(messageReaction, user);
 
                     logger.info.should.have.been.calledOnce;
                     logger.info.should.have.been.calledWithExactly(`Training requested by ${username} (${userId})`);

--- a/test/unit/events/message-reaction-add/handlers/request-training.test.ts
+++ b/test/unit/events/message-reaction-add/handlers/request-training.test.ts
@@ -215,11 +215,11 @@ describe('RequestTrainingHandler', () => {
 
             return handler.handle(messageReaction, user)
                 .then(result => {
-                    giveTrainingStub.should.have.been.calledOnce;
-                    giveTrainingStub.should.have.been.calledWithExactly(user, messageReaction);
-
                     removeUserFromMessageReactionStub.should.have.been.calledOnce;
                     removeUserFromMessageReactionStub.should.have.been.calledWithExactly(messageReaction, user);
+
+                    giveTrainingStub.should.have.been.calledOnce;
+                    giveTrainingStub.should.have.been.calledWithExactly(user, messageReaction);
 
                     logger.info.should.not.have.been.called;
 
@@ -233,11 +233,11 @@ describe('RequestTrainingHandler', () => {
         it('should resolve void after successfully handling the messageReaction', () => {
             return handler.handle(messageReaction, user)
                 .then(result => {
-                    giveTrainingStub.should.have.been.calledOnce;
-                    giveTrainingStub.should.have.been.calledWithExactly(user, messageReaction);
-
                     removeUserFromMessageReactionStub.should.have.been.calledOnce;
                     removeUserFromMessageReactionStub.should.have.been.calledWithExactly(messageReaction, user);
+
+                    giveTrainingStub.should.have.been.calledOnce;
+                    giveTrainingStub.should.have.been.calledWithExactly(user, messageReaction);
 
                     logger.info.should.have.been.calledOnce;
                     logger.info.should.have.been.calledWithExactly(`Training requested by ${username} (${userId})`);

--- a/test/unit/events/message-reaction-remove/handlers/cancel-training-request.test.ts
+++ b/test/unit/events/message-reaction-remove/handlers/cancel-training-request.test.ts
@@ -1,0 +1,163 @@
+import sinon, { stubInterface, StubbedInstance, stubObject } from 'ts-sinon';
+import { MessageReaction, User } from 'discord.js';
+import { should } from 'chai';
+
+import { CancelTrainingRequestHandler } from '../../../../../src/events/message-reaction-remove/handlers/cancel-training-request';
+
+
+describe('CancelRequestTrainingHandler', () => {
+    const messageId = 'some-message-id';
+    const emojiName = 'some-emoji-name';
+
+    let handler: CancelTrainingRequestHandler;
+
+    let sandbox: sinon.SinonSandbox;
+
+    before(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    beforeEach(() => {
+        handler = new CancelTrainingRequestHandler(messageId, emojiName);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('constructor', () => {
+        it('should construct an instance as expected', () => {
+            handler.should.be.deep.equal({
+                messageId,
+                emojiName,
+            });
+        });
+
+        it('should construct an instance as expected - secondary', () => {
+            const messageId = 'another-message-id';
+            const emojiName = 'another-emoji-name';
+
+            handler = new CancelTrainingRequestHandler(messageId, emojiName);
+
+            handler.should.be.deep.equal({
+                messageId,
+                emojiName,
+            });
+        });
+    });
+
+    describe('supported', () => {
+        let messageReaction: MessageReaction;
+        let user: User;
+
+        beforeEach(() => {
+            messageReaction = {
+                message: { id: messageId },
+                emoji: { name: emojiName }
+            } as MessageReaction;
+            user = { bot: false } as User;
+        });
+
+        it('should throw an error if the messageReaction is undefined', () => {
+            messageReaction = undefined;
+            should().not.exist(messageReaction);
+
+            return Promise.resolve()
+                .then(() => handler.supported(messageReaction, user))
+                .then(() => {
+                    throw new Error('Expected an error to be thrown but got success');
+                }, err => {
+                    err.should.be.an.instanceOf(Error);
+                    err.message.should.be.equal(`Cannot read property 'emoji' of undefined`);
+                });
+        });
+
+        it('should throw an error if the messageReaction.emoji is undefined', () => {
+            messageReaction = { message: { id: messageId } } as MessageReaction;
+            should().not.exist(messageReaction.emoji);
+
+            return Promise.resolve()
+                .then(() => handler.supported(messageReaction, user))
+                .then(() => {
+                    throw new Error('Expected an error to be thrown but got success');
+                }, err => {
+                    err.should.be.an.instanceOf(Error);
+                    err.message.should.be.equal(`Cannot read property 'name' of undefined`);
+                });
+        });
+
+        it('should return true if the user is undefined', () => {
+            user = undefined;
+            should().not.exist(user);
+
+            const result = handler.supported(messageReaction, user);
+            result.should.be.true;
+        });
+
+        it('should throw an error if the messageReaction.message is undefined', () => {
+            messageReaction.message = undefined;
+            should().not.exist(messageReaction.message);
+
+            return Promise.resolve()
+                .then(() => handler.supported(messageReaction, user))
+                .then(() => {
+                    throw new Error('Expected an error to be thrown but got success');
+                }, err => {
+                    err.should.be.an.instanceOf(Error);
+                    err.message.should.be.equal(`Cannot read property 'id' of undefined`);
+                });
+        });
+
+        it('should return false if the emojiName does not match', () => {
+            messageReaction.emoji.name = 'some other emoji';
+            messageReaction.emoji.name.should.be.not.equal(emojiName);
+
+            const result = handler.supported(messageReaction, user);
+            result.should.be.false;
+        });
+
+        it('should return true if the user is a bot', () => {
+            user.bot = true;
+            user.bot.should.be.true;
+
+            const result = handler.supported(messageReaction, user);
+            result.should.be.true;
+        });
+
+        it('should return false if the messageId does not match', () => {
+            messageReaction.message.id = 'some other message id';
+            messageReaction.message.id.should.be.not.equal(messageId);
+
+            const result = handler.supported(messageReaction, user);
+            result.should.be.false;
+        });
+
+        it('should return true if all criteria are met', () => {
+            const result = handler.supported(messageReaction, user);
+            result.should.be.true;
+        });
+    });
+
+    describe('handle', () => {
+        const userId = '123';
+        const username = 'some user';
+
+        let messageReaction: StubbedInstance<MessageReaction>;
+        let user: StubbedInstance<User>;
+
+        beforeEach(() => {
+            messageReaction = stubInterface<MessageReaction>();
+            user = stubObject<User>({
+                id: userId,
+                username
+            } as User);
+        });
+
+        it('should resolve without doing anything', () => {
+            return handler.handle(messageReaction, user)
+                .then(result => {
+                    should().not.exist(result);
+                });
+        });
+    });
+});

--- a/test/unit/events/message-reaction-remove/handlers/index.test.ts
+++ b/test/unit/events/message-reaction-remove/handlers/index.test.ts
@@ -1,10 +1,12 @@
 import * as MessageReactionRemoveHandlersModule from '../../../../../src/events/message-reaction-remove/handlers';
+import { CancelTrainingRequestHandler } from '../../../../../src/events/message-reaction-remove/handlers/cancel-training-request';
 import { RevokeRoleHandler } from '../../../../../src/events/message-reaction-remove/handlers/revoke-role';
 
 
 describe('MessageReactionRemoveHandlersModule', () => {
     it('should export the expected resources', () => {
         MessageReactionRemoveHandlersModule.should.be.deep.equal({
+            CancelTrainingRequestHandler,
             RevokeRoleHandler
         });
     });

--- a/test/unit/events/message-reaction-remove/index.test.ts
+++ b/test/unit/events/message-reaction-remove/index.test.ts
@@ -1,10 +1,12 @@
 import * as MessageReactionRemoveModule from '../../../../src/events/message-reaction-remove';
+import { CancelTrainingRequestHandler } from '../../../../src/events/message-reaction-remove/handlers/cancel-training-request';
 import { RevokeRoleHandler } from '../../../../src/events/message-reaction-remove/handlers/revoke-role';
 
 
 describe('MessageReactionRemoveModule', () => {
     it('should export the expected resources', () => {
         MessageReactionRemoveModule.should.be.deep.equal({
+            CancelTrainingRequestHandler,
             RevokeRoleHandler
         });
     });

--- a/test/unit/lib/discord-helper.test.ts
+++ b/test/unit/lib/discord-helper.test.ts
@@ -18,7 +18,9 @@ describe('DiscordHelpers', () => {
 
     before(() => {
         sandbox = sinon.createSandbox();
+    });
 
+    beforeEach(() => {
         fakeDefaultRetry = async (func: () => any | Promise<any>): Promise<any> => {
             return await func();
         };

--- a/test/unit/lib/helpers.test.ts
+++ b/test/unit/lib/helpers.test.ts
@@ -1,6 +1,9 @@
 import sinon from 'ts-sinon';
+import BluebirdRetry from 'bluebird-retry';
 
-import { jsonParser, jsonReviver, } from '../../../src/lib/helpers';
+import { should } from 'chai';
+
+import { jsonParser, jsonReviver, defaultRetry, retry, factory } from '../../../src/lib/helpers';
 
 describe('Helper', () => {
     let sandbox: sinon.SinonSandbox;
@@ -63,6 +66,147 @@ describe('Helper', () => {
             const value = 596423;
             const result = jsonReviver('', value);
             result.should.be.equal(value);
+        });
+    });
+
+    describe('defaultRetry', () => {
+        let retryStub: sinon.SinonStub<[() => any | Promise<any>, BluebirdRetry.Options], Promise<any>>;
+        let stub: sinon.SinonStub<[], string>;
+
+        beforeEach(() => {
+            retryStub = sandbox.stub(factory, 'retry');
+            stub = sandbox.stub<[], string>();
+        });
+
+        it('should invoke retry with the supplied func and the expected default options', () => {
+            return defaultRetry(stub)
+                .then(result => {
+                    retryStub.should.have.been.calledOnce;
+                    retryStub.should.have.been.calledWithExactly(stub, { max_tries: 5, interval: 25, backoff: 2 });
+
+                    stub.should.not.have.been.called;
+
+                    should().not.exist(result);
+                });
+        });
+    });
+
+    describe('retry', () => {
+        const MAX_TRIES = 5;
+        const fakeResult = 'Hello world';
+
+        let options: BluebirdRetry.Options;
+
+        beforeEach(() => {
+            options = { max_tries: MAX_TRIES, interval: 2 };
+        });
+
+        describe('with synchronous functions', () => {
+            let stub: sinon.SinonStub<[], string>;
+
+            beforeEach(() => {
+                stub = sandbox.stub<[], string>().returns(fakeResult);
+            });
+
+            it('should reject any error thrown by func after attempting the max allowd times', () => {
+                const error = new Error('Some fake error');
+                stub.throws(error);
+
+                return retry(stub, options)
+                    .then(() => {
+                        throw new Error('Expected an error to be thrown but got success');
+                    }, err => {
+                        stub.should.have.callCount(MAX_TRIES);
+                        for (let i = 0; i < MAX_TRIES; i++) {
+                            stub.getCall(i).should.have.been.calledWithExactly();
+                        }
+
+                        err.should.be.equal(error);
+                    });
+            });
+
+            it('should resolve the result of func when func failed but eventually succeeds', () => {
+                const error = new Error('Some fake error');
+                const allowedToErrorCount = MAX_TRIES - 1;
+
+                for (let i = 0; i < allowedToErrorCount; i++) {
+                    stub.onCall(i).throws(error);
+                }
+
+                return retry(stub, options)
+                    .then(result => {
+                        stub.should.have.callCount(MAX_TRIES);
+                        for (let i = 0; i < MAX_TRIES; i++) {
+                            stub.getCall(i).should.have.been.calledWithExactly();
+                        }
+
+                        result.should.be.equal(fakeResult);
+                    });
+            });
+
+            it('should resolve the result of func when func succeeds on first attempt', () => {
+                return retry(stub, options)
+                    .then(result => {
+                        stub.should.have.been.calledOnce;
+                        stub.should.have.been.calledWithExactly();
+
+                        result.should.be.equal(fakeResult);
+                    });
+            });
+        });
+
+        describe('with asynchronous functions', () => {
+            let stub: sinon.SinonStub<[], Promise<string>>;
+
+            beforeEach(() => {
+                stub = sandbox.stub<[], Promise<string>>().resolves(fakeResult);
+            });
+
+            it('should reject any error thrown by func after attempting the max allowd times', () => {
+                const error = new Error('Some fake error');
+                stub.rejects(error);
+
+                return retry(stub, options)
+                    .then(() => {
+                        throw new Error('Expected an error to be thrown but got success');
+                    }, err => {
+                        stub.should.have.callCount(MAX_TRIES);
+                        for (let i = 0; i < MAX_TRIES; i++) {
+                            stub.getCall(i).should.have.been.calledWithExactly();
+                        }
+
+                        err.should.be.equal(error);
+                    });
+            });
+
+            it('should resolve the result of func when func failed but eventually succeeds', () => {
+                const error = new Error('Some fake error');
+                const allowedToErrorCount = MAX_TRIES - 1;
+
+                for (let i = 0; i < allowedToErrorCount; i++) {
+                    stub.onCall(i).rejects(error);
+                }
+
+                return retry(stub, options)
+                    .then(result => {
+                        stub.should.have.callCount(MAX_TRIES);
+                        for (let i = 0; i < MAX_TRIES; i++) {
+                            stub.getCall(i).should.have.been.calledWithExactly();
+                        }
+
+                        result.should.be.equal(fakeResult);
+                    });
+            });
+
+            it('should resolve the result of func when func succeeds on first attempt', () => {
+                return retry(stub, options)
+                    .then(result => {
+                        stub.should.have.been.calledOnce;
+                        stub.should.have.been.calledWithExactly();
+
+                        result.should.be.equal(fakeResult);
+                    });
+            });
         });
     });
 });

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,5 @@
 {
-    "extends": 
-        "tslint-config-security"
-    ,
+    "extends": "tslint-config-security",
     "rules": {
         "class-name": false,
         "comment-format": [
@@ -23,12 +21,15 @@
             "check-open-brace",
             "check-whitespace"
         ],
-        "quotemark": [ 
-            true, 
-            "single", 
+        "quotemark": [
+            true,
+            "single",
             "avoid-escape"
         ],
-        "semicolon": [true, "always"],
+        "semicolon": [
+            true,
+            "always"
+        ],
         "triple-equals": [
             true,
             "allow-null-check"
@@ -55,7 +56,14 @@
             "check-separator",
             "check-type"
         ],
-        "space-before-function-paren": [true, "never"],
+        "space-before-function-paren": [
+            true,
+            {
+                "anonymous": "always",
+                "named": "never",
+                "asyncArrow": "always"
+            }
+        ],
         "eofline": true
     }
 }


### PR DESCRIPTION
This code change will have the added reaction removed when the user requests training, rather than removing all reactions and then re-adding a single reaction.

This was intended to resolve https://github.com/accbh/discordbot/issues/8 but now an warning was being logged for not handling the removal of the single reaction.

A CancelTrainingRequestHandler was added to avoid this message from being logged.

Many unit test updates to boot